### PR TITLE
Propose solution for issue #34 - perform basic validation on request

### DIFF
--- a/app/controllers/download_report_controller.rb
+++ b/app/controllers/download_report_controller.rb
@@ -6,9 +6,10 @@ class DownloadReportController < ApplicationController
     layout = whole_page?(params) && 'application'
     @report_manager = ReportManager.new(params: params)
 
-    respond_to do |format|
-      format.html { render :show, layout: layout }
-      format.json { render json: @report_manager }
+    if @report_manager.valid?
+      render_report(layout)
+    else
+      render_not_valid(layout)
     end
   end
 
@@ -20,5 +21,19 @@ class DownloadReportController < ApplicationController
 
   def whole_page?(params)
     !partial_page?(params)
+  end
+
+  def render_report(layout)
+    respond_to do |format|
+      format.html { render :show, layout: layout }
+      format.json { render json: @report_manager }
+    end
+  end
+
+  def render_not_valid(layout)
+    respond_to do |format|
+      format.html { render :bad_request, layout: layout, status: :bad_request }
+      format.json { render json: {}, status: :bad_request }
+    end
   end
 end

--- a/app/views/download_report/bad_request.html.haml
+++ b/app/views/download_report/bad_request.html.haml
@@ -1,0 +1,6 @@
+%h1.heading-large Invalid request
+
+%p
+  Your request could not be processed, due to:
+  %code
+    = @report_manager.errors

--- a/test/services/report_manager_test.rb
+++ b/test/services/report_manager_test.rb
@@ -14,4 +14,75 @@ class ReportManagerTest < ActiveSupport::TestCase
     rm.latest_year.must_equal 2015
     rm.latest_month_spec.must_equal '2015-09'
   end
+
+  it 'should permit valid requests' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+    api.stubs(:post_json).returns(test_double: true)
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'region',
+      area: 'EAST MIDLANDS',
+      aggregate:  'county',
+      period: %w[ytd 2018],
+      age:  'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    rm.valid?.must_equal true
+    rm.errors.must_be_nil
+  end
+
+  it 'should reject invalid requests (no period)' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'region',
+      area: 'EAST MIDLANDS',
+      aggregate:  'county',
+      age:  'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    rm.valid?.must_equal false
+    rm.errors.must_equal 'missing parameter period'
+  end
+
+  it 'should reject invalid requests (no value for period)' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'region',
+      area: 'EAST MIDLANDS',
+      aggregate:  'county',
+      period: [],
+      age:  'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    rm.valid?.must_equal false
+    rm.errors.must_equal 'missing parameter period'
+  end
+
+  it 'should reject invalid requests (no area)' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'region',
+      aggregate:  'county',
+      period: [2018],
+      age:  'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    rm.valid?.must_equal false
+    rm.errors.must_equal 'missing parameter area'
+  end
 end


### PR DESCRIPTION
parameters. If an standard report is requested via the app, it will - by
construction - have all of the necessary parameters. However, since we
serialise the request state to the URL so that the report is
bookmarkable, this means that some users may treat the URL as an API,
and change some of the parameters. In particular, omitting, say, the
report period puts the back-end report generator into a failure state.
To prevent this, I have added some basic validation of the request
parameters. This could be made more robust - it basically checks for
presence, not that the values are from a permitted range. However, a
missing param will now produce an HTTP status 400 from the app rather
than pass a malformed request to the back end.