### PR TITLE
Issue/40 parameter injection defense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Standard Reports UI: change log
 
+## 1.1.3 - 2019-12-11
+
+- Add validation to avoid SPARQL-injection attack via postal codes
+
 ## 1.1.2 - 2019-12-09
 
 - Add `ActionController::BadRequest` to the list of exceptions that

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 2
+  PATCH = 3
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/app/models/report_specification.rb
+++ b/app/models/report_specification.rb
@@ -14,6 +14,8 @@ class ReportSpecification
   private
 
   def normalize_period(report_manager)
+    return unless @params[:period].respond_to?(:to_sym)
+
     case @params[:period].to_sym
     when :ytd
       @params[:period] = report_manager.latest_year

--- a/app/models/step_select_postcode_area.rb
+++ b/app/models/step_select_postcode_area.rb
@@ -2,6 +2,8 @@
 
 # Workflow step of selecting a postcode area
 class StepSelectPostcodeArea < StepSelectPostcode
+  VALIDATION = /\A[A-Z][A-Z]?\Z/.freeze
+
   def initialize
     super(:select_pc_area)
   end
@@ -15,7 +17,7 @@ class StepSelectPostcodeArea < StepSelectPostcode
   end
 
   def validation_pattern
-    /\A[A-Z][A-Z]?\Z/
+    VALIDATION
   end
 
   def input_label

--- a/app/models/step_select_postcode_district.rb
+++ b/app/models/step_select_postcode_district.rb
@@ -2,6 +2,8 @@
 
 # Workflow step of selecting a postcode district
 class StepSelectPostcodeDistrict < StepSelectPostcode
+  VALIDATION = /\A[A-Z][A-Z]?[0-9][0-9]?[A-Z]?\Z/.freeze
+
   def initialize
     super(:select_pc_district)
   end
@@ -15,7 +17,7 @@ class StepSelectPostcodeDistrict < StepSelectPostcode
   end
 
   def validation_pattern
-    /\A[A-Z][A-Z]?[0-9][0-9]?[A-Z]?\Z/
+    VALIDATION
   end
 
   def input_label

--- a/app/models/step_select_postcode_sector.rb
+++ b/app/models/step_select_postcode_sector.rb
@@ -2,6 +2,8 @@
 
 # Workflow step of selecting a postcode sector
 class StepSelectPostcodeSector < StepSelectPostcode
+  VALIDATION = /\A[A-Z][A-Z]?[0-9][0-9]?[A-Z]? [0-9]\Z/.freeze
+
   def initialize
     super(:select_pc_sector)
   end
@@ -15,7 +17,7 @@ class StepSelectPostcodeSector < StepSelectPostcode
   end
 
   def validation_pattern
-    /\A[A-Z][A-Z]?[0-9][0-9]?[A-Z]? [0-9]\Z/
+    VALIDATION
   end
 
   def input_label

--- a/app/services/report_manager.rb
+++ b/app/services/report_manager.rb
@@ -106,6 +106,8 @@ class ReportManager
     key_present?(params, :age)
     array_key_present?(params, :period)
 
+    valid_postcodes?(params) if valid?
+
     valid?
   end
 
@@ -122,5 +124,25 @@ class ReportManager
 
     @errors ||= []
     @errors << "missing parameter #{key}"
+  end
+
+  def valid_postcodes?(params)
+    area = params[:area]
+    pattern = validation_pattern(params)
+
+    return unless pattern && !pattern.match?(area)
+
+    @errors ||= []
+    @errors << 'invalid postal code'
+  end
+
+  def validation_pattern(params)
+    area_type = params[:areaType].to_sym
+
+    {
+      pcSector: StepSelectPostcodeSector::VALIDATION,
+      pcDistrict: StepSelectPostcodeDistrict::VALIDATION,
+      pcArea: StepSelectPostcodeArea::VALIDATION
+    }[area_type]
   end
 end

--- a/test/services/report_manager_test.rb
+++ b/test/services/report_manager_test.rb
@@ -85,4 +85,58 @@ class ReportManagerTest < ActiveSupport::TestCase
     _(rm.valid?).must_equal false
     _(rm.errors).must_equal 'missing parameter area'
   end
+
+  it 'should reject postal-district area types that do not have a valid postcode' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'pcDistrict',
+      area: '; select wombles from wimbledon',
+      aggregate: 'county',
+      period: [2018],
+      age: 'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    _(rm.valid?).must_equal false
+    _(rm.errors).must_equal 'invalid postal code'
+  end
+
+  it 'should reject postcode-area area types that do not have a valid postcode' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'pcArea',
+      area: '; select wombles from wimbledon',
+      aggregate: 'county',
+      period: [2018],
+      age: 'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    _(rm.valid?).must_equal false
+    _(rm.errors).must_equal 'invalid postal code'
+  end
+
+  it 'should reject postcode-sector area types that do not have a valid postcode' do
+    api = mock('report_manager_api')
+    api.stubs(:get).returns('2015-09')
+
+    params = ActionController::Parameters.new(
+      report: 'avgPrice',
+      areaType: 'pcSector',
+      area: '; select wombles from wimbledon',
+      aggregate: 'county',
+      period: [2018],
+      age: 'any'
+    )
+
+    rm = ReportManager.new(api: api, params: params)
+    _(rm.valid?).must_equal false
+    _(rm.errors).must_equal 'invalid postal code'
+  end
 end


### PR DESCRIPTION
Validates postal codes for: postcode sector, postcode area, and postcode district. Attempts to inject a SPARQL query via the postcode parameter should now return a 400 error.

Addresses #40

@bwmcbride @MalcolmShazell I have deployed a fixed version (`1.1.3`) to the dev server.