### PR TITLE
Revert "Fix rubocop errors"

### DIFF
--- a/app/helpers/download_request_helper.rb
+++ b/app/helpers/download_request_helper.rb
@@ -29,20 +29,20 @@ module DownloadRequestHelper
   end
 
   def render_unknown_request(request)
-    tag(:span, class: 'o-request--status__warning') do
+    content_tag(:span, class: 'o-request--status__warning') do
       "Request #{request.id} was not recognised as a valid report request."
     end
   end
 
   def render_failed_request(request)
-    tag(:span, class: 'o-request--status__warning') do
-      "Request #{request.id} did not complete successfully." \
-        'Ideally we will put more info here. In the meantime, please check the log file'
+    content_tag(:span, class: 'o-request--status__warning') do
+      "Request #{request.id} did not complete successfully. " + "
+      Ideally we will put more info here. In the meantime, please check the log file"
     end
   end
 
   def render_completed_request(request) # rubocop:disable Metrics/MethodLength
-    tag(:span, class: 'o-request--status__success') do
+    content_tag(:span, class: 'o-request--status__success') do
       concat('Ready: ')
       concat(tag(:br))
       concat(

--- a/app/models/step_select_report.rb
+++ b/app/models/step_select_report.rb
@@ -19,10 +19,10 @@ class StepSelectReport < Step
     case state_value.to_sym
     when :avgPrice
       "<span class='c-review-report--summary-key'>report type #{connector}</span>" \
-      "<span class='c-review-report--summary-value'>average prices and volumes</span>"
+        "<span class='c-review-report--summary-value'>average prices and volumes</span>"
     when :banded
       "<span class='c-review-report--summary-key'>report type #{connector}</span>" \
-      "<span class='c-review-report--summary-value'>banded prices</span>"
+        "<span class='c-review-report--summary-value'>banded prices</span>"
     else
       'unknown report type!'
     end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -81,7 +81,7 @@ class Workflow # rubocop:disable Metrics/ClassLength
   end
 
   def params
-    @params ||= @state.select { |k, _v| allowlist_key(k) }
+    @params ||= @state.select { |k, _v| whitelist_key(k) }
   end
 
   def_delegator :params, :each, :each_state_key
@@ -92,7 +92,7 @@ class Workflow # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def allowlist_key(key)
+  def whitelist_key(key)
     step_with_param(key)
   end
 


### PR DESCRIPTION
This reverts commit 7c2db6bc5db81df15687f8856d9cd2007d9ff7b3.

In particular, the tag/content tag change recommended by Rubocop caused
the app not to work correctly
