### PR TITLE
Update logging to consistently emit JSON

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,3 +35,24 @@ module StandardReportsUi
     config.autoload_paths << Rails.root.join('services')
   end
 end
+
+# Monkey-patch the bit of Rails that emits the start-up log message, so that it
+# is written out in JSON format that our combined logging service can handle
+# This version is Rails 5.x specific. A different pattern is needed for Rails 6
+# applications.
+module Rails
+  # :nodoc:
+  class Server
+    # :nodoc:
+    def print_boot_information
+      url = "on #{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
+
+      msg = {
+        level: 'INFO',
+        ts: DateTime.now.rfc3339(3),
+        message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+      }
+      puts msg.to_json
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,10 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  config.log_tags = %i[subdomain request_id request_method]
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,15 +46,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.log_tags = %i[subdomain request_id request_method]
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -73,14 +67,9 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  # config.log_formatter = ::Logger::Formatter.new
+  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
 
-  config.logger = JsonRailsLogger::Logger.new($stdout)
-
-  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || '/'
-
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
+  config.api_service_url = ENV['API_SERVICE_URL']
 
   config.accessibility_document_path = '/accessibility'
   config.privacy_document_path = '/privacy'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
+threads min_threads_count, max_threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch('PORT', 3000)
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch('RAILS_ENV', 'development')
+
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+# Use a custom log formatter to emit Puma log messages in a JSON format
+log_formatter do |str|
+  {
+    level: 'INFO',
+    ts: DateTime.now.rfc3339(3),
+    message: str
+  }.to_json
+end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ fi
 
 if [ -z "API_SERVICE_URL" ]
 then
-  echo "{'ts': ${date}, 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+  echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo API_SERVICE_URL:  ${API_SERVICE_URL}
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'Standard Reports starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'minitest/rails/capybara'
 require 'mocha/minitest'
 
 require 'minitest/reporters'
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/vcr_cassettes'


### PR DESCRIPTION
Update the logging in the standard reports app to more consisently emit
JSON-formatted messages:

- ensure `entrypoint.sh` emits JSON with correct timestamp format
- Rails and Puma startup emit JSON
- use `json-rails-logger` as the main log formatter
