### PR TITLE
Update to Sentry-Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'leaflet-rails'
 gem 'puma'
 gem 'prometheus-client', '~> 4.0'
 gem 'responders', '~> 2.0'
-gem 'sentry-raven'
+gem 'sentry-ruby', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,8 +298,11 @@ GEM
       ffi (~> 1.9)
     sdoc (1.1.0)
       rdoc (>= 5.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-ruby (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sentry-ruby-core (= 5.2.1)
+    sentry-ruby-core (5.2.1)
+      concurrent-ruby
     sexp_processor (4.16.0)
     spring (3.1.1)
     sprockets (3.7.2)
@@ -399,7 +402,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   sdoc (~> 1.1.0)
-  sentry-raven
+  sentry-ruby (~> 5.2)
   spring
   uglifier (>= 1.3.0)
   unicorn

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ application as
 We use a number of environment variables to determine the runtime behaviour
 of the application:
 
-| name                       | description                                                          | typical value                                    |
-| -------------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/standard-reports`                          |
-| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`                          |
+| name                       | description                                                          | typical value            |
+| -------------------------- | -------------------------------------------------------------------- | ------------------------ |
+| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/standard-reports`  |
+| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`  |
+| `SENTRY_API_KEY`           | The Sentry DSN for sending exceptions and errors to Sentry           |                          |

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,12 @@
 # frozen-string-literal: true
 
-Raven.configure do |config|
-  config.dsn = config.dsn = 'https://96fe8408c7cf4b789a47bf3866897353@sentry.io/1859755'
-  config.current_environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
-  config.environments = %w[production test]
-  config.release = Version::VERSION
-  config.tags = { app: 'lr-dgu-std-reports' }
-  config.excluded_exceptions += ['ActionController::BadRequest']
+if ENV['SENTRY_API_KEY']
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_API_KEY']
+    config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+    config.enabled_environments = %w[production test]
+    config.release = Version::VERSION
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
+    config.excluded_exceptions += ['ActionController::BadRequest']
+  end
 end


### PR DESCRIPTION
This commit updates the Sentry library to the recommended `sentry-rails`
version, and updates the initialisation block to use the new API.

In addition, we have factored out the DSN key to be passed in as an
environment variable.
