### PR TITLE
Updated default ENV vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Standard Reports UI: change log
 
+## 1.4.1 - 2022-07-11
+
+- (Jon) Set the default root path environment variable to be `/app/standard-reports`
+ in the production environment as well as updated variable requests to use `fetch`
+  to future proof the codebase
+
 ## 1.4.0 - 2022-04-07
 
 - (Ian) Adopt all of the current Epimorphics best-practice deployment patterns,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,7 @@ PLATFORMS
   -darwin-20
   aarch64-linux
   x86_64-darwin-17
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -412,4 +413,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.5
+   2.3.13

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 4
-  PATCH = 0
+  PATCH = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
 
   config.assets.quiet = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'] || true
+  config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', true)
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -67,14 +67,14 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
+  config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/standard-reports')
 
-  config.api_service_url = ENV['API_SERVICE_URL']
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
 
   config.accessibility_document_path = '/accessibility'
   config.privacy_document_path = '/privacy'
 end
 
 JsRoutes.setup do |config|
-  config.prefix = ENV['RAILS_RELATIVE_URL_ROOT'] || '/'
+  config.prefix = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/standard-reports')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
 
   config.accessibility_document_path = '/doc/accessibility'
   config.privacy_document_path = '/doc/privacy'


### PR DESCRIPTION
This PR resolves the https://github.com/epimorphics/hmlr-linked-data/issues/100 ticket

- Updated the specific environment variables to use the `fetch` method to set the default value when the requested variable is not found
- Set the production environment to use `/app/standard-reports` as default `RAILS_RELATIVE_URL_ROOT` instead of `/`
