### PR TITLE
Set the `change_default_caching_policy` in the app `before_action`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Standard Reports UI: change log
 
+## 1.5.0.1 - 2023-07-11
+
+- (Jon) Updated the `app/controllers/application_controller.rb` to include the
+  `before_action` for the `change_default_caching_policy` method to ensure the
+  default `Cache-Control` header for all requests is set to 5 minutes (300 seconds).
+
 ## 1.5.0 - 2023-07-05
 
 - (Jon) This sets the cache control headers to be public and cacheable with a

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :change_default_caching_policy
+
   around_action :log_request_result
   def log_request_result
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -4,6 +4,6 @@ module Version
   MAJOR = 1
   MINOR = 5
   PATCH = 0
-  SUFFIX = nil
+  SUFFIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
Using `before_action`s let's us "prepare" the data necessary before the action in the controller executes. In this case setting the cache headers to the desired length.

https://github.com/epimorphics/hmlr-linked-data/issues/114
