### PR TITLE
updates step 3/7 to return user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.3 - 2024-08
 
+- (Dan) Updates step 3/7 to return user input rather than false when user inputs invalid value [118](https://github.com/epimorphics/standard-reports-ui/issues/118)
 - (Dan) Adds underline text to laning page of standard reports and to help link[114](https://github.com/epimorphics/standard-reports-ui/issues/114)
 - (Dan) Styled the help button to match PPD [117](https://github.com/epimorphics/standard-reports-ui/issues/117)
 - (Dan) Adds more descriptive text to action buttons on the report page [115](https://github.com/epimorphics/standard-reports-ui/issues/115)

--- a/app/models/step_select_county_or_district.rb
+++ b/app/models/step_select_county_or_district.rb
@@ -18,16 +18,17 @@ class StepSelectCountyOrDistrict < StepSelectArea
   end
 
   def validate_value(workflow)
+    input_text = value(workflow)
     normalized_value = validate(value(workflow))
     unless normalized_value && (value(workflow) == normalized_value)
-      workflow.set_state(param_name, normalized_value)
+      workflow.set_state(param_name, input_text)
     end
 
-    normalized_value || validation_failure(workflow)
+    normalized_value || validation_failure(input_text)
   end
 
-  def validation_failure(workflow)
-    set_flash("Sorry, #{subtype_label} '#{value(workflow)}' was not recognised")
+  def validation_failure(input_text)
+    set_flash("Sorry, #{subtype_label} '#{input_text}' was not recognised")
     false
   end
 


### PR DESCRIPTION
This updates the error message to contain the user's input rather than the text false. In this case 'Lutons'.

Please see this ticket https://github.com/epimorphics/standard-reports-ui/issues/118

NOTE: I have manually tested this change and it works well across the app.

![Screenshot from 2024-08-14 13-55-20](https://github.com/user-attachments/assets/3b60bd7d-ae41-4c30-b2aa-b42431264878)

