### PR TITLE
Updates error message to be more helpful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.3 - 2024-08
 
-- (Dan) Update the error message for the postcode sector step 3/7 [120](https://github.com/epimorphics/standard-reports-ui/issues/120)
+- (Dan) Update the error message for the postcode selectors step 3/7 [120](https://github.com/epimorphics/standard-reports-ui/issues/120)
 - (Dan) Updates step 3/7 to return user input rather than false when user inputs invalid value [118](https://github.com/epimorphics/standard-reports-ui/issues/118)
 - (Dan) Adds underline text to laning page of standard reports and to help link[114](https://github.com/epimorphics/standard-reports-ui/issues/114)
 - (Dan) Styled the help button to match PPD [117](https://github.com/epimorphics/standard-reports-ui/issues/117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.3 - 2024-08
 
+- (Dan) Update the error message for the postcode sector step 3/7 [120](https://github.com/epimorphics/standard-reports-ui/issues/120)
 - (Dan) Updates step 3/7 to return user input rather than false when user inputs invalid value [118](https://github.com/epimorphics/standard-reports-ui/issues/118)
 - (Dan) Adds underline text to laning page of standard reports and to help link[114](https://github.com/epimorphics/standard-reports-ui/issues/114)
 - (Dan) Styled the help button to match PPD [117](https://github.com/epimorphics/standard-reports-ui/issues/117)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.3)
+    lr_common_styles (1.9.4)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -402,7 +402,7 @@ DEPENDENCIES
   json_rails_logger (~> 1.0.0)!
   leaflet-rails
   libv8-node (>= 16.10.0.0)
-  lr_common_styles (~> 1.9.3)!
+  lr_common_styles (~> 1.9, >= 1.9.4)!
   minitest-rails-capybara
   minitest-reporters
   minitest-spec-rails

--- a/app/models/step_select_postcode.rb
+++ b/app/models/step_select_postcode.rb
@@ -23,7 +23,8 @@ class StepSelectPostcode < StepSelectArea
       workflow_update_hook(workflow)
       workflow.traverse_to(successor_step)
     else
-      set_flash("Sorry, '#{value}' does not appear to be a valid value for a #{subtype_label}.")
+      set_flash("Sorry, '#{value}' does not appear to be a valid value for a #{subtype_label}.
+      Have you left a space between between the digits?")
     end
   end
 

--- a/app/models/step_select_postcode.rb
+++ b/app/models/step_select_postcode.rb
@@ -24,7 +24,7 @@ class StepSelectPostcode < StepSelectArea
       workflow.traverse_to(successor_step)
     else
       set_flash("Sorry, '#{value}' does not appear to be a valid value for a #{subtype_label}.
-      Have you left a space between the digits?")
+      Perhaps there's a typo or too many characters or maybe an extra space somewhere?")
     end
   end
 

--- a/app/models/step_select_postcode.rb
+++ b/app/models/step_select_postcode.rb
@@ -24,7 +24,7 @@ class StepSelectPostcode < StepSelectArea
       workflow.traverse_to(successor_step)
     else
       set_flash("Sorry, '#{value}' does not appear to be a valid value for a #{subtype_label}.
-      Have you left a space between between the digits?")
+      Have you left a space between the digits?")
     end
   end
 


### PR DESCRIPTION
The improvement in the spread sheet wording is as follows:

_Error message given to user as "not valid value for (geographical area type)" more context could be given to user to suggest type of error and help with correcting. Step 3/7 requires a space which is documented in clear instructions, but the error message could indicate that no space has been included or reiterate format instructions above with an example._

I have simply added the following text to the error message:

Have you left a space between the digits?

![Screenshot from 2024-08-14 16-16-34](https://github.com/user-attachments/assets/1db7b301-1d6c-4cb6-bf3e-e02e9addc636)
