### PR TITLE
Adds underline link to report file page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.3 - 2024-08
 
+- (Dan) Updates report page styles so links are underlined and gives download report page a seperate page title
 - (Dan) Updates gemfile to use v1.9.5 lr_common_styles
 - (Dan) Updates the page titles throughout the app [116](https://github.com/epimorphics/standard-reports-ui/issues/116)
 - (Dan) Updates the button text on reports page to be dynamic and adds aria labels to help screen readers [119](https://github.com/epimorphics/standard-reports-ui/issues/119)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.4)
+    lr_common_styles (1.9.5)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -402,7 +402,7 @@ DEPENDENCIES
   json_rails_logger (~> 1.0.0)!
   leaflet-rails
   libv8-node (>= 16.10.0.0)
-  lr_common_styles (~> 1.9, >= 1.9.4)!
+  lr_common_styles (~> 1.9, >= 1.9.5)!
   minitest-rails-capybara
   minitest-reporters
   minitest-spec-rails

--- a/app/helpers/download_request_helper.rb
+++ b/app/helpers/download_request_helper.rb
@@ -46,12 +46,12 @@ module DownloadRequestHelper
       concat('Ready: ')
       concat(tag(:br))
       concat(
-        link_to("Microsoft Excel format <i class='fa fa-external-link'></i>".html_safe,
+        link_to("Microsoft Excel format <i class='fa fa-external-link text-link'></i>".html_safe,
                 request.url(:xlsx))
       )
       concat(tag(:br))
       concat(
-        link_to("open-data (csv) format <i class='fa fa-external-link'></i>".html_safe,
+        link_to("open-data (csv) format <i class='fa fa-external-link text-link'></i>".html_safe,
                 request.url(:csv))
       )
     end

--- a/app/views/download_report/show.html.haml
+++ b/app/views/download_report/show.html.haml
@@ -28,7 +28,7 @@
 
   %p.text-muted
     To create additional reports, you can
-    = link_to( "return to the start", controller: :report_design, action: :show)
+    = link_to( "return to the start", controller: :report_design, action: :show, class: "text-link")
     of this application.
 
 

--- a/app/views/download_report/show.html.haml
+++ b/app/views/download_report/show.html.haml
@@ -1,3 +1,5 @@
+= content_for(:title, "Download your report file")
+
 - n = @report_manager.requests.length
 
 .download-report


### PR DESCRIPTION
I have been unable to reproduce this locally for various reasons so I don't have any screenshots.

However, the changes I have made should fix the issues Jon has highlighted on the report page, where links that do not have an underline should now have an underline.

And the download report page now has a separate title.

