### PR TITLE
Application Configuration Unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.4 - 2024-09
 
+- (Jon) Moved all mirrored configuration settings from individual environments
+  into the application configuration to reduce the need to manage multiple
+  sources of truth
 - (Jon) Implemented improved boilerplate metrics integration to offer analysis
   of current application usage stats
 - (Jon) Added `process_threads` gauge to prometheus metrics alongside isolating
@@ -29,10 +32,15 @@
 
 ## 1.5.3 - 2024-09
 
-- (Dan) Fixes bug XXS vulnerability [133](https://github.com/epimorphics/standard-reports-ui/issues/133)
-- (Dan) Update the error messages for the postcode selectors step 3/7 so each error message is unique to the postcode selector [120](https://github.com/epimorphics/standard-reports-ui/issues/120)
-- (Dan) Updates alt text for screenshots of example reports [115](https://github.com/epimorphics/standard-reports-ui/issues/115)
-- (Dan) Updates report page styles so links are underlined and gives download report page a seperate page title
+- (Dan) Fixes bug XXS vulnerability
+  [133](https://github.com/epimorphics/standard-reports-ui/issues/133)
+- (Dan) Update the error messages for the postcode selectors step 3/7 so each
+  error message is unique to the postcode selector
+  [120](https://github.com/epimorphics/standard-reports-ui/issues/120)
+- (Dan) Updates alt text for screenshots of example reports
+  [115](https://github.com/epimorphics/standard-reports-ui/issues/115)
+- (Dan) Updates report page styles so links are underlined and gives download
+  report page a seperate page title
 - (Dan) Updates gemfile to use v1.9.5 lr_common_styles
 - (Dan) Updates the page titles throughout the app
   [116](https://github.com/epimorphics/standard-reports-ui/issues/116)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,14 +367,14 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.7)
+    lr_common_styles (1.9.8)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
       govuk_frontend_toolkit (~> 4.18.1)
       govuk_template (~> 0.18.1)
       haml-rails (~> 2.0.0)
-      jquery-rails (~> 4.3.5)
+      jquery-rails (>= 4.3.5, < 4.7.0)
       lodash-rails (~> 4.17.14)
       modernizr-rails (~> 2.7.1)
       modulejs-rails (~> 2.2.0.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module StandardReportsUi
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Use default paths for documentation.
+    config.accessibility_document_path = '/accessibility'
+    config.privacy_document_path = '/privacy'
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,8 +54,4 @@ Rails.application.configure do
 
   # API location can be specified in the environment but defaults to the dev service
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/doc/accessibility'
-  config.privacy_document_path = '/doc/privacy'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,10 +90,6 @@ Rails.application.configure do
   # set in the Makefile as an env variable for the docker container when run as an image.
   # API_SERVICE_URL is required by both Docker image and Rails
   config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/accessibility'
-  config.privacy_document_path = '/privacy'
 end
 
 JsRoutes.setup do |config|

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,8 +47,4 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/doc/accessibility'
-  config.privacy_document_path = '/doc/privacy'
 end


### PR DESCRIPTION
Moved all mirrored configuration settings from individual environments into the application configuration to reduce the need to manage multiple sources