### PR TITLE
Hotfix: Improved Logging instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 1.5.4 - 2024-10
 
-- (Jon) Wrapped the Internal Error Instrumentation in an `unless` block to ensure the
-  application does not report internal errors to the Prometheus metrics when the
-  error is a 404 or 422 thereby reducing the noise in the Slack alerts channel
+- (Jon) Wrapped the Internal Error Instrumentation in an `unless` block to
+  ensure the application does not report internal errors to the Prometheus
+  metrics when the error is a 404 or 422 thereby reducing the noise in the Slack
+  alerts channel
 
 ## 1.5.3 - 2024-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Standard Reports UI: change log
 
+## 1.5.4 - 2024-10
+
+- (Jon) Wrapped the Internal Error Instrumentation in an `unless` block to ensure the
+  application does not report internal errors to the Prometheus metrics when the
+  error is a 404 or 422 thereby reducing the noise in the Slack alerts channel
+
 ## 1.5.3 - 2024-09
 
 - (Jon) Updated the application exceptions controller to instrument the

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,10 @@ class ApplicationController < ActionController::Base
   # or attempt to render a generic error page if no specific error page exists
   unless Rails.application.config.consider_all_requests_local
     rescue_from StandardError do |e|
-      # Instrument ActiveSupport::Notifications for internal errors:
-      ActiveSupport::Notifications.instrument('internal_error.application', exception: e)
+      # Instrument ActiveSupport::Notifications for internal errors but only for non-404 errors:
+      unless e.is_a?(ActionController::RoutingError) || e.is_a?(ActionView::MissingTemplate)
+        ActiveSupport::Notifications.instrument('internal_error.application', exception: e)
+      end
       # Trigger the appropriate error handling method based on the exception
       case e.class
       when ActionController::RoutingError, ActionView::MissingTemplate
@@ -104,7 +106,7 @@ class ApplicationController < ActionController::Base
       body: request.body.gets&.gsub("\n", '\n'),
       method: request.method,
       status: response.status,
-      message: Rack::Utils::HTTP_STATUS_CODES[response.status]
+      message: response.message || Rack::Utils::HTTP_STATUS_CODES[response.status]
     }
 
     case response.status

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 5
-  PATCH = 3
+  PATCH = 4
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR includes the following changes in order to reduce the log noise as a result of improved error handling in the application:

- Wrapped the Internal Error Instrumentation in an unless block to ensure the application does not report internal errors to the Prometheus metrics when the error is a 404 or 422 thereby reducing the noise in the Slack alerts channel
