### PR TITLE
Task: Prep for Release Candidate v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 2.2.1 - 2025-08
+
+- Updated LR Common Styles gem to continue to address security issues
 - Upgrades dependencies, including Rails, to address security issues
 - Improved environment configs for logging and error tracking
 - Updates tooling and lock files for smoother development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,8 +479,8 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (2.2.2)
-      bootstrap-sass (~> 3.4)
+    lr_common_styles (2.3.0)
+      bootstrap-sass (~> 3.4.1)
       font-awesome-rails (~> 4.7.0)
       govuk_elements_rails (= 3.0.2)
       govuk_frontend_toolkit (~> 9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       railties (>= 4.0)
     net-http (0.6.0)
       uri
-    net-imap (0.5.9)
+    net-imap (0.5.10)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 2
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This pull request includes a minor version bump and updates the changelog to reflect recent dependency upgrades and security improvements.

Version and changelog updates:

* Incremented the patch version to `2.2.1` in `app/lib/version.rb` to prepare for a new release.
* Added a new entry for version `2.2.1` in `CHANGELOG.md`, highlighting the update of the LR Common Styles gem and ongoing dependency/security improvements.