### PR TITLE
Issue/182 replace ruby sass with dartsass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ tags
 
 # Ignore Standard Reports Manager configuration file download logs
 wget-log
+
+# Ignore local TODO files
+TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-01
+
+### Added
+
+- Enabled Sass source maps for front-end debugging in development
+- Added Autoprefixer with source map generation for CSS debugging
+- Added root CSS variables for consistent styling
+
+### Changed
+
+- Replaced `sass-rails` with `dartsass-sprockets` for Dart Sass compatibility
+  [#182](https://github.com/epimorphics/standard-reports-ui/issues/182)
+- Updated `lr_common_styles` gem (includes Bootstrap 5)
+- Modernised stylesheets with Bootstrap conventions
+- Improved form control layout and button styles
+- Enhanced report styling with improved font sizes and spacing
+- Updated report detail toggle text for clarity
+- Simplified layout templates by removing unnecessary elements
+- Improved Sentry initialisation with better environment control
+- Streamlined Makefile for improved development workflow
+- Configured Sass compression in production for smaller bundles
+
+### Removed
+
+- Removed deprecated `sass-rails` gem and redundant dependencies
+
 ## [2.2.2] - 2025-11
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -8,18 +8,6 @@ gem 'rails'
 # Use Puma as the app server
 gem 'puma'
 
-# Assets group is temporarily disabled due to versioning issues with Rails
-# group :assets do
-# Use SCSS for stylesheets
-gem 'sass-rails'
-# ! Webpacker removes the need for Uglifier so we can safely remove it.
-# ! If you want to use Uglifier, uncomment the line below
-# ! and ensure you have the 'uglifier' gem in your Gemfile.
-# ! See https://www.mintbit.com/blog/rails-5-6-upgrade-es6-uglifier-bug/
-# Use Uglifier as compressor for JavaScript assets
-# gem 'uglifier', require: false
-# end
-
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'execjs'
 
@@ -28,23 +16,22 @@ gem 'libv8-node'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', group: :doc
-
-# LR-common dependencies
-gem 'bootstrap-sass'
-gem 'font-awesome-rails'
-gem 'haml-rails'
 gem 'jquery-rails'
-gem 'modernizr-rails'
-gem 'modulejs-rails'
 
-# application dependencies
-gem 'faraday'
+gem 'autoprefixer-rails'
+gem 'dartsass-sprockets', '~> 3.2'
+
+gem 'haml-rails'
+
+gem 'rubocop'
+gem 'rubocop-rails'
+
+gem 'faraday', '~> 2.13'
 gem 'faraday-encoding', '>= 0.0.6'
 gem 'faraday-follow_redirects', '>= 0.3.0'
 gem 'faraday-retry', '>= 2.0'
 
+gem 'font-awesome-rails'
 gem 'get_process_mem'
 gem 'jquery-ui-rails'
 gem 'js-routes'
@@ -52,17 +39,21 @@ gem 'leaflet-rails'
 gem 'prometheus-client'
 gem 'puma-metrics'
 gem 'responders'
-gem 'sentry-rails'
 gem 'yajl-ruby', require: 'yajl'
 
+# Sentry uses stackprof for performance profiling, has to be loaded before Sentry
+gem 'stackprof'
+gem 'sentry-rails' # rubocop:disable Bundler/OrderedGems
+
+group :doc do
+  gem 'sdoc', require: false
+end
 gem 'byebug', groups: %i[development test]
 gem 'dotenv', groups: %i[development test]
 
 group :development, :test do
   gem 'foreman'
   gem 'ostruct'
-  gem 'rubocop'
-  gem 'rubocop-rails'
 end
 
 group :test do
@@ -76,6 +67,7 @@ group :test do
 end
 
 group :development do
+  gem 'htmlbeautifier'
   gem 'ruby-lsp'
   gem 'solargraph'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
@@ -86,6 +78,10 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console'
+  # TODO: While running the rails app locally for testing you can set gems to your local path
+  # ! These 'local' paths do not work with a docker image - use the repo instead
+  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
+  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
 end
 
 # TODO: In production you want to set this to the gem from the epimorphics group package repository
@@ -94,7 +90,3 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'lr_common_styles'
 end
 
-# TODO: For gem development and testing, you can use the local path to the gem
-# ! These "local" paths do not work with a docker image - use the remote gem instead
-# gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,8 @@ GEM
     benchmark (0.5.0)
     bigdecimal (3.3.1)
     bindex (0.8.1)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+    bootstrap (5.3.5)
+      popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
     byebug (12.0.0)
     capybara (3.40.0)
@@ -115,6 +114,12 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.0)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
@@ -151,6 +156,27 @@ GEM
       ffi (~> 1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.33.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     govuk_elements_rails (3.0.2)
       govuk_frontend_toolkit (>= 5.2.0)
       rails (>= 4.1.0)
@@ -169,6 +195,7 @@ GEM
       haml (>= 4.0.6)
       railties (>= 5.1)
     hashdiff (1.2.0)
+    htmlbeautifier (1.4.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -285,6 +312,7 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    popper_js (2.11.8)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -391,19 +419,27 @@ GEM
     ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
+    sass-embedded (1.97.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     sdoc (2.6.1)
       rdoc (>= 5.0)
     securerandom (0.4.1)
@@ -443,6 +479,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    stackprof (0.2.27)
     stringio (3.1.7)
     temple (0.10.4)
     thor (1.4.0)
@@ -486,8 +523,8 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (2.3.1)
-      bootstrap-sass (~> 3.4.1)
+    lr_common_styles (3.0.0)
+      bootstrap (~> 5.3.2)
       font-awesome-rails (~> 4.7.0)
       govuk_elements_rails (= 3.0.2)
       govuk_frontend_toolkit (~> 9.0)
@@ -498,7 +535,6 @@ GEM
       modernizr-rails (~> 2.7)
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0)
-      sass-rails (~> 6.0)
 
 PLATFORMS
   aarch64-linux
@@ -513,11 +549,12 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  bootstrap-sass
+  autoprefixer-rails
   byebug
+  dartsass-sprockets (~> 3.2)
   dotenv
   execjs
-  faraday
+  faraday (~> 2.13)
   faraday-encoding (>= 0.0.6)
   faraday-follow_redirects (>= 0.3.0)
   faraday-retry (>= 2.0)
@@ -525,6 +562,7 @@ DEPENDENCIES
   foreman
   get_process_mem
   haml-rails
+  htmlbeautifier
   jbuilder
   jquery-rails
   jquery-ui-rails
@@ -539,8 +577,6 @@ DEPENDENCIES
   minitest-spec-rails
   minitest-vcr
   mocha
-  modernizr-rails
-  modulejs-rails
   ostruct
   prometheus-client
   puma
@@ -550,11 +586,11 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   ruby-lsp
-  sass-rails
   sdoc
   sentry-rails
   solargraph
   spring
+  stackprof
   vcr
   web-console
   webmock

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-.PHONY:	assets auth check clean image lint publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint publish realclean run tag test update vars
 
-ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.22
-AWS_REGION?=eu-west-1
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
+RUBY_VERSION?=$(shell cat .ruby-version)
+ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
+AWS_REGION?=eu-west-1
 ECR?=${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3003
-RUBY_VERSION?=$(shell cat .ruby-version)
+
 SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 STAGE?=dev
 API_SERVICE_URL?=http://localhost:8081
@@ -24,9 +25,9 @@ TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
-GITHUB_TOKEN=.github-token
 BUNDLE_CFG=.bundle/config
 BUNDLE=./bin/bundle
+GITHUB_TOKEN=.github-token
 RAILS=./bin/rails
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
@@ -35,20 +36,25 @@ ${BUNDLE_CFG}: ${GITHUB_TOKEN}
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
 
-all: image
+all: image ## Default target: build the Docker image
 
-assets:
-	@echo "Installing bundled gems ..."
+assets: bundles compiled ## Compile assets for serving
+	@echo assets completed.
+
+auth: ${GITHUB_TOKEN} ${BUNDLE_CFG} ## Set up authentication for GitHub and Bundler
+	@echo "Authentication set up for GitHub and Bundler."
+
+bundles: ## Install Ruby gems via Bundler
+	@echo "Installing Ruby gems via Bundler..."
 	@${BUNDLE} install
-	@echo "Cleaning and precompiling static assets ..."
-	@${BUNDLE} exec rake assets:clean assets:precompile
 
-auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
-
-check: lint test
+check: checks ## Alias for `checks` target
 	@echo "All checks passed."
 
-clean:
+checks: lint test ## Run all checks: linting and tests
+	@echo "All checks passed."
+
+clean: ## Clean up temporary and compiled files
 	@echo "Cleaning up ${SHORTNAME} files..."
 # Clean up the project
 	@[ -d public/assets ] && ${RAILS} assets:clobber || :
@@ -57,7 +63,21 @@ clean:
 # Remove temporary files and directories
 	@@ rm -rf bundle coverage log node_modules tmp
 
-image: auth
+compiled: ## Compile assets for production
+	@echo "Cleaning and precompiling static assets ..."
+	@${RAILS} assets:clobber assets:precompile
+
+forceclean: realclean ## Remove all bundled files
+	@${BUNDLE} clean --force || :
+
+help: ## Display this message
+	@echo "Available make targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Environment variables (optional: all variables have defaults):"
+	@make vars
+
+image: auth ## Build the Docker image
 	@echo Building ${REPO}:${TAG} ...
 	@docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -73,48 +93,59 @@ image: auth
 		.
 	@echo Done.
 
-forceclean: realclean
-# Remove all bundled files
-	@${BUNDLE} clean --force || :
+lint: rubocop ## Run linting checks
+	@echo "All linting complete."
 
-lint: assets
-	@${BUNDLE} exec rubocop
-
-name:
+name: ## Display the shortname of the application
 	@echo ${SHORTNAME}
 
-publish: image
+publish: image ## Publish the Docker image to the registry
 	@echo Publishing image: ${REPO}:${TAG} ...
 	@docker tag ${NAME}:${TAG} ${REPO}:${TAG} 2>&1
 	@docker push ${REPO}:${TAG} 2>&1
 	@echo Done.
 
-realclean: clean
+realclean: clean ## Remove all generated files and authentication
 	@echo "Removing authentication from ${SHORTNAME}..."
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
-run: start
+rubocop: ## Run RuboCop linting
+	@echo "Running RuboCop linting for ${SHORTNAME} ..."
+# Auto-correct offenses safely where possible with the `-a` flag
+	@${BUNDLE} exec rubocop -a
+
+run: start ## Run the Docker container locally
 	@if docker network inspect dnet > /dev/null 2>&1; then echo "Using docker network dnet"; else echo "Create docker network dnet"; docker network create dnet; sleep 2; fi
 	@docker run ${RUN_VARS} ${PORT}:3000 --env API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
-server: start
+server: start ## Run the Rails server locally
 	@API_SERVICE_URL=${API_SERVICE_URL} ${RAILS} server -p ${PORT}
 
-start: stop
+start: stop ## Start the application
 	@echo "Starting ${SHORTNAME} pointing to ${API_SERVICE_URL} API ..."
 
-stop:
+stop: ## Stop the application
 	@echo "Stopping ${SHORTNAME} ..."
 	@docker stop ${SHORTNAME} > /dev/null 2>&1 || :
 
-tag:
+tag: ## Display the Docker image tag
 	@echo ${TAG}
 
-test: assets
-	@echo "Running tests ..."
+test: ## Run unit tests
+	@echo "Running unit tests ..."
+# Run Rails tests
 	@${RAILS} test
 
-vars:
+update: ## Review and update dependencies interactively
+	@echo "Checking for outdated dependencies..."
+	@if [ -f package.json ]; then \
+		echo "Running yarn upgrade-interactive..."; \
+		yarn upgrade-interactive; \
+	fi
+	@echo "Running bundle outdated to check Ruby gems..."
+	@bundle outdated --only-explicit
+
+vars: ## Display environment variables
 	@echo "Docker: ${REPO}:${TAG}"
 	@echo "ACCOUNT = ${ACCOUNT}"
 	@echo "ALPINE_VERSION = ${ALPINE_VERSION}"
@@ -131,5 +162,5 @@ vars:
 	@echo "TAG = ${TAG}"
 	@echo "VERSION = ${VERSION}"
 
-version:
+version: ## Display the application version
 	@echo ${VERSION}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,10 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require popper
 //= require bootstrap
 //= require lr_common_styles/application
+//
 //= require jquery-ui/widgets/autocomplete
 //= require leaflet
 //= require lodash

--- a/app/assets/javascripts/report_type.js
+++ b/app/assets/javascripts/report_type.js
@@ -6,8 +6,8 @@ document.addEventListener("DOMContentLoaded", function() {
     detail.addEventListener('toggle', function() {
       const isHidden = !detail.open;
       span.textContent = span.textContent.replace(
-        isHidden ? 'close' : 'view',
-        isHidden ? 'view' : 'close'
+        isHidden ? 'close the' : 'view an',
+        isHidden ? 'view an' : 'close the'
       );
     });
   });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,30 +1,13 @@
 /*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any styles
- * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
- * file per style scope.
- *
  *= require jquery-ui
  *= depend_on_asset "layers.png"
  *= depend_on_asset "layers-2x.png"
  */
 
-@import
-  "govuk-template",
-  "govuk-elements",
-  "bootstrap-sprockets",
-  "bootstrap",
-  "font-awesome",
-  "lr_common_styles/lr-common",
-  "leaflet",
-  "standard-reports";
-
-  .text-link {
-      text-decoration: underline;
-  }
+@import "govuk-template";
+@import "govuk-elements";
+@import "bootstrap";
+@import "font-awesome";
+@import "lr_common_styles/lr-common";
+@import  "leaflet";
+@import  "standard-reports";

--- a/app/assets/stylesheets/standard-reports.scss
+++ b/app/assets/stylesheets/standard-reports.scss
@@ -1,4 +1,13 @@
-$grey-1: #6f777b;
+:root {
+  --srui-font-size-base: 1.0rem;
+  --srui-h3-size: 2.4rem; // 24px equivalent
+  --srui-button-padding-vertical: 0.5rem;
+  --srui-button-padding-horizontal: 1rem;
+  --srui-grey-1: #6f777b;
+  --srui-gutter-x: 1.5rem;
+}
+
+$grey-1: var(--srui-grey-1);
 
 :focus,
 a:focus,
@@ -13,7 +22,6 @@ input:focus {
 
 .form-control:focus {
   border: 0;
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 
@@ -28,29 +36,86 @@ ol.numbered {
 
 input[type=checkbox],
 input[type=radio] {
-  -webkit-transform: scale(1.5);
   transform: scale(1.5);
+}
+
+details {
+  .summary {
+    font-weight: 400;
+    font-size: medium;
+  }
+}
+
+// layout
+.o-container,
+#content {
+  padding-inline: 1.5rem;
+
+  @media (min-width: 768px) {
+    &.container {
+      width: 750px;
+    }
+  }
+
+  @media (min-width: 992px) {
+    &.container {
+      width: 960px;
+    }
+  }
+
+  h3.fs-1 {
+    font-size: var(--srui-h3-size) !important;
+  }
+}
+
+/* Form controls */
+
+.list-unstyled {
+  list-style-position: inside;
+
+  label {
+    padding-inline-start: 1.5rem;
+  }
+}
+
+%form-label {
+  font-weight: 700;
+  display: block;
 }
 
 .o-form-control {
   line-height: 3rem;
 
-  .o-form-control--input {
+  .list-inline {
+    @media(min-width: 576px) {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  }
+
+  &--item_inline {
+    display: inline-block;
+    margin-inline-end: 2rem;
+    flex: 0 0 max-content;
+  }
+
+  &--input {
     margin-right: 0.8rem;
   }
 
-  .o-form-control--label {
-    display: block;
+  &--label {
+    @extend %form-label;
+
+    &_inline {
+      @extend %form-label;
+      display: inline-block;
+    }
+
+    input[type=text] {
+      width: 100%;
+    }
   }
 
-  .o-form-control--label-inline {
-    display: inline-block;
-  }
-
-  .o-form-control--label input[type=text] {
-    // margin-left: 0.8rem;
-    width: 100%;
-  }
 }
 
 /* components */
@@ -75,7 +140,7 @@ input[type=radio] {
   display: flex;
   align-items: center;
 
-  > * {
+  >* {
     margin-right: 1em;
   }
 }
@@ -99,19 +164,23 @@ input[type=radio] {
     margin-bottom: 1rem;
   }
 
-  details > .panel {
+  details>.panel {
     display: none;
-    -webkit-box-shadow: none;
     box-shadow: none;
   }
 
-  details[open] > .panel {
+  details[open]>.panel {
     display: block;
+
     &:has(picture) {
       overflow-x: auto;
       overflow-y: hidden;
       width: auto;
       max-width: 100%;
+    }
+
+    &:not(:has(picture)) {
+      padding-inline: unset;
     }
   }
 }
@@ -147,6 +216,13 @@ input[type=radio] {
   font-size: 90%
 }
 
+.ui-menu {
+  .ui-menu-item {
+    display: block;
+    font-size: calc(var(--srui-font-size-base) + 0.4rem);
+    white-space: nowrap;
+  }
+}
 
 .button--secondary,
 .button--secondary:visited,
@@ -154,7 +230,6 @@ input[type=radio] {
 .button--secondary:hover {
   color: #0b0c0c !important;
   background-color: #f3f2f1;
-  -webkit-box-shadow: 0 2px 0 #929191;
   box-shadow: 0 2px 0 #929191;
 }
 
@@ -163,19 +238,25 @@ input[type=radio] {
 .button[disabled="disabled"] {
   color: #6f777b !important;
   background-color: #f3f2f1;
-  -webkit-box-shadow: none;
   box-shadow: none;
-  &:not([type=submit]){
+
+  &:not([type=submit]) {
     &:hover {
       cursor: default;
       background-color: #f3f2f1;
     }
+
     &:focus,
     &:active {
       top: 0;
-      -webkit-box-shadow: none;
       box-shadow: none;
-      outline: none !important; /* prevent focus ring - overriding previous !important */
+      /* prevent focus ring - overriding previous !important */
+      outline: none !important;
     }
   }
+}
+
+// Migrated from application.scss - to be removed from there once standard-reports.scss is imported
+.text-link {
+  text-decoration: underline;
 }

--- a/app/helpers/report_design_helper.rb
+++ b/app/helpers/report_design_helper.rb
@@ -228,7 +228,7 @@ module ReportDesignHelper # rubocop:disable Metrics/ModuleLength
     link_to(
       'change&hellip;'.html_safe,
       workflow.params.merge(stop: step.param_name),
-      class: 'c-review-report--change-option copy-14',
+      class: 'c-review-report--change-option',
       'aria-label' => "change report option #{step.name}"
     )
   end

--- a/app/helpers/report_design_helper.rb
+++ b/app/helpers/report_design_helper.rb
@@ -136,7 +136,7 @@ module ReportDesignHelper # rubocop:disable Metrics/ModuleLength
     year = Time.current.year - delta
     content_tag(:div, class: 'row') do
       concat(content_tag(:div, class: 'col-sm-12 col-md-1') do
-        content_tag(:h3, year.to_s, class: 'u-font-bold u-align-top')
+        content_tag(:h3, year.to_s, class: 'u-font-bold u-align-top fs-1')
       end)
       concat(content_tag(:div, class: 'col-sm-12 col-md-11') do
         concat(layout_all_year(step, year, workflow))
@@ -180,7 +180,7 @@ module ReportDesignHelper # rubocop:disable Metrics/ModuleLength
 
   def prompted_row(main_block)
     capture do
-      content_tag(:div, class: 'col-sm-12 col-md-10') do
+      content_tag(:div, class: 'col-sm-12 col-md-11 px-3') do
         content_tag(:div, class: 'o-form-control') do
           main_block.call
         end
@@ -189,13 +189,13 @@ module ReportDesignHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def labelled_check_box_li(param_name, value, label, checked)
-    content_tag(:li, class: 'o-form-control--label-inline') do
+    content_tag(:li, class: 'o-form-control--item_inline') do
       labelled_check_box(param_name, value, label, checked)
     end
   end
 
   def labelled_check_box(param_name, value, label, checked)
-    content_tag(:label, class: 'o-form-control--label-inline') do
+    content_tag(:label, class: 'o-form-control--label_inline') do
       concat check_box_tag(
         "#{param_name}#{value}",
         value.to_s, checked,

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 2
-  MINOR = 2
-  PATCH = 2
+  MINOR = 3
+  PATCH = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end

--- a/app/views/common/_footer.html.haml
+++ b/app/views/common/_footer.html.haml
@@ -18,5 +18,3 @@
             All content is available under the
             %a{:href => "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3"} Open Government Licence v3.0
             except where otherwise stated
-
-        .clearfix

--- a/app/views/report_design/_help.html.haml
+++ b/app/views/report_design/_help.html.haml
@@ -1,4 +1,4 @@
-.o-help-link
+.o-help-link.pe-1
   = link_to "https://www.gov.uk/guidance/price-paid-data-standard-reports#guidance-on-searching-the-data", class: "button button--secondary", alt: "Help and tips", title: "Help and tips" do
     %i.fa.fa-question-circle
     help

--- a/app/views/report_design/select_dates.html.haml
+++ b/app/views/report_design/select_dates.html.haml
@@ -28,8 +28,7 @@
         re-load the same report at a later date, the report will be automatically
         updated.
 
-      .clearfix
-        = layout_values_as_toggle_buttons_list( step, values[:latest], false, "col-sm-12 col-md-11 col-md-offset-1" )
+      = layout_values_as_toggle_buttons_list( step, values[:latest], false, "col-sm-12 col-md-11 offset-md-1" )
 
       %h2.heading-small
         Choose specific dates
@@ -46,5 +45,3 @@
             = layout_custom_dates( years_ago, step, @workflow )
 
     = layout_submit_button( @workflow )
-
-.clearfix

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,20 +2,15 @@
 
 require File.expand_path('boot', __dir__)
 
-# require 'rails'
 # Pick the frameworks you want:
-# require 'active_model/railtie'
-# require 'active_job/railtie'
-# require "active_record/railtie"
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
-# require 'action_view/railtie'
 require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+Bundler.require(:default, Rails.env)
 
 module StandardReportsUi
   # :nodoc:
@@ -39,24 +34,33 @@ module StandardReportsUi
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Quiet SASS deprecation warnings coming from dependencies
+    config.sass.quiet_deps = true
+    # Silence @import deprecation warnings during migration to @use/@forward
+    # See: https://sass-lang.com/d/import
+    config.sass.silence_deprecations = ['import']
+    # Add services path to autoload paths
     config.autoload_paths << Rails.root.join('services')
   end
 end
 
-# Monkey-patch the bit of Rails that emits the start-up log message, so that it
-# is written out in JSON format that our combined logging service can handle
+# Monkey-patch the bit of Rails that emits the start-up log message, so
+# that it is written out in JSON format that our combined logging
+# service can handle
 module Rails
   # :nodoc:
   module Command
     # :nodoc:
     class ServerCommand
       def print_boot_information(server, url)
-        msg = {
+        msg = "Starting #{server} Rails #{Rails.version} in #{Rails.env}"
+        msg += " on #{url}" if url
+        info = {
           ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
           level: 'INFO',
-          message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+          message: msg
         }
-        say msg.to_json
+        say info.to_json
       end
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   # Don't print a log message every time an asset file is loaded
   config.assets.quiet = true
 
+  # Enable SASS source maps in development for easier debugging
+  config.sass.inline_source_maps = true
   # Tag rails logs with useful information
   config.log_tags = %i[subdomain request_id request_method]
   # When sync mode is true, all output is immediately flushed to the underlying

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,6 +36,11 @@ Rails.application.configure do
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
+  # `config.sass.style` has been deprecated in favor of `config.assets.css_compressor`
+  # Set SASS output style to compressed for smaller file sizes
+  config.sass.style = :compressed
+  # SASS source maps are disabled in production for performance
+  config.sass.inline_source_maps = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to
   # config/initializers/assets.rb

--- a/config/initializers/autoprefixer.rb
+++ b/config/initializers/autoprefixer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Configure Autoprefixer to generate source maps for easier debugging of CSS
+# See: https://github.com/tablecheck/dartsass-sprockets/issues/23#issuecomment-2408131105
+class AutoprefixerWithSourcemap < AutoprefixerRails::Sprockets
+  def self.run(filename, css)
+    output = "#{filename.chomp(File.extname(filename))}.css"
+
+    # If you want this nice an generic, you could check `css` for the presence
+    # of an inline source map, and set the `map` argument based on that
+    # instead of always setting it to `true`.
+    result = @processor.process(css, from: filename, to: output, map: true)
+
+    result.warnings.each do |warning|
+      warn "autoprefixer: #{warning}"
+    end
+
+    result.css
+  end
+
+  def self.use_bundle_processor?
+    ::Sprockets::VERSION.to_f >= 4
+  end
+
+  def self.install(env)
+    if use_bundle_processor?
+      env.register_bundle_processor('text/css', self)
+    else
+      env.register_postprocessor('text/css', self)
+    end
+  end
+
+  def self.uninstall(env)
+    if use_bundle_processor?
+      env.unregister_bundle_processor('text/css', self)
+    else
+      env.unregister_postprocessor('text/css', self)
+    end
+  end
+end
+
+Rails.application.config.assets.configure do |env|
+  AutoprefixerRails.uninstall(env)
+  AutoprefixerWithSourcemap.register_processor(AutoprefixerRails.processor({}))
+  AutoprefixerWithSourcemap.install(env)
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,43 +3,44 @@
 require 'version'
 
 Rails.application.reloader.to_prepare do
-  if ENV['SENTRY_API_KEY']
-    Sentry.init do |config|
-      # https://docs.sentry.io/platforms/ruby/configuration/options/#breadcrumbs-logger
-      config.breadcrumbs_logger = %i[sentry_logger monotonic_active_support_logger http_logger]
-      # * The DSN tells the SDK where to send events.
-      config.dsn = ENV['SENTRY_API_KEY']
-      # ! Only report errors in these environments:
-      config.enabled_environments = %w[production prod preprod dev]
-      # ! Ignore exceptions that are not useful to us
-      config.excluded_exceptions += [
-        'ActionController::BadRequest',
-        'ActionController::RoutingError',
-        'ActiveRecord::RecordNotFound'
-      ]
-      # * Set the environment name from the SENTRY_ENVIRONMENT configuration value
-      config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
-      # ^ Default to only reporting info, warnings and errors to Sentry
-      config.logger.level = Rails.application.config.log_level || :info
-      # * Set the release version to the current version
-      config.release = Version::VERSION
-      # * Set traces_sample_rate to 1.0 to capture 100% of transactions for tracing.
-      config.traces_sample_rate = Rails.env.development? ? 1.0 : 0.1
-      # ! Sentry recommends adjusting this value in production hence the ternary operator.
-      # * Set profiles_sample_rate to profile 100% of sampled transactions.
-      config.profiles_sample_rate = Rails.env.production? ? 1.0 : 0.1
-      # ! Sentry recommends adjusting this value in production hence the ternary operator.
-    end
-
-    # * Set additional tags for the Sentry event to allow for better filtering in the Sentry UI
-    # ? These tags are set in either a local .env file or the instance configuration
-    # ! `.compact!` removes any nil values from the sentry_tags hash before setting the tags
-    sentry_tags = {
-      'band' => ENV.fetch('SENTRY_BAND', nil),
-      'enabled' => ENV.fetch('SENTRY_ENABLED', nil),
-      'hostname' => ENV.fetch('SENTRY_HOSTNAME', nil)
-    }.compact!
-    # * Set the tags in the Sentry event with remaining values but only if there are any
-    sentry_tags&.each { |k, v| Sentry.set_tags(k.to_s => v) }
+  Sentry.init do |config|
+    # https://docs.sentry.io/platforms/ruby/configuration/options/#breadcrumbs-logger
+    config.breadcrumbs_logger = %i[sentry_logger monotonic_active_support_logger http_logger]
+    # * The DSN tells the SDK where to send events.
+    # ! By default, events will be sent to Sentry in all environments.
+    # ! If you don't want to send events in a specific environment,
+    # ! you can unset the SENTRY_DSN [SENTRY_API_KEY] variable in that environment.
+    config.dsn = ENV['SENTRY_API_KEY']
+    # ! Only report errors in these environments:
+    config.enabled_environments = %w[production prod preprod dev]
+    # ! Ignore exceptions that are not useful to us
+    config.excluded_exceptions += [
+      'ActionController::BadRequest',
+      'ActionController::RoutingError',
+      'ActiveRecord::RecordNotFound'
+    ]
+    # * Set the environment name from the SENTRY_ENVIRONMENT instance configuration value
+    config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
+    # ^ Default to only reporting info, warnings and errors to Sentry
+    config.sdk_logger.level = Rails.application.config.log_level || :info
+    # * Set the release version to the current version
+    config.release = Version::VERSION
+    # * Set traces_sample_rate to 1.0 to capture 100% of transactions for tracing.
+    config.traces_sample_rate = Rails.env.development? ? 1.0 : 0.1
+    # ! Sentry recommends adjusting this value in production hence the ternary operator.
+    # * Set profiles_sample_rate to profile 100% of sampled transactions.
+    config.profiles_sample_rate = Rails.env.production? ? 1.0 : 0.1
+    # ! Sentry recommends adjusting this value in production hence the ternary operator.
   end
+
+  # * Set additional tags for the Sentry event to allow for better filtering in the Sentry UI
+  # ? These tags are set in either a local .env file or the instance configuration
+  # ! `.compact!` removes any nil values from the sentry_tags hash before setting the tags
+  sentry_tags = {
+    'band' => ENV.fetch('SENTRY_BAND', nil),
+    'enabled' => ENV.fetch('SENTRY_ENABLED', nil),
+    'hostname' => ENV.fetch('SENTRY_HOSTNAME', nil)
+  }.compact!
+  # * Set the tags in the Sentry event with remaining values but only if there are any
+  sentry_tags&.each { |k, v| Sentry.set_tags(k.to_s => v) }
 end


### PR DESCRIPTION
## Summary

Replaced deprecated `sass-rails` gem with Dart Sass and updated styling for Bootstrap 5 compatibility.

Specific to ticket #182

## Changes

- Replaced `sass-rails` with `dartsass-sprockets` for Dart Sass compatibility
- Updated `lr_common_styles` gem (includes Bootstrap 5)
- Enabled Sass source maps for front-end debugging
- Added Autoprefixer with source map generation
- Modernised stylesheets with Bootstrap conventions
- Improved Sentry initialisation with better environment control
- Streamlined Makefile for improved development workflow

## Breaking Changes

None

## Checklist

### Testing
- [x] Manual testing completed
- [x] No regressions introduced

### Build & Assets
- [x] Assets compile successfully
- [x] Linting passes (rubocop, eslint)
- [x] Docker image builds successfully

### Process & Quality
- [x] Changelog updated