### PR TITLE
chore: Pin gem versions and remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,16 +5,10 @@ source 'https://rubygems.org'
 ruby file: '.ruby-version'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails'
+gem 'rails', '~> 8.1'
 
 # Use Puma as the app server
-gem 'puma'
-
-# See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'execjs'
-
-# gem 'therubyracer', platforms: :ruby
-gem 'libv8-node'
+gem 'puma', '~> 7.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
@@ -24,9 +18,6 @@ gem 'autoprefixer-rails'
 gem 'dartsass-sprockets', '~> 3.2'
 
 gem 'haml-rails'
-
-gem 'rubocop'
-gem 'rubocop-rails'
 
 # Faraday v2 requires individual middlewares to be specified
 # Resolve open-ended gem versioning warnings by setting explicit version minimums
@@ -47,7 +38,7 @@ gem 'yajl-ruby', require: 'yajl'
 
 # Sentry uses stackprof for performance profiling, has to be loaded before Sentry
 gem 'stackprof'
-gem 'sentry-rails' # rubocop:disable Bundler/OrderedGems
+gem 'sentry-rails', '~> 6.0' # rubocop:disable Bundler/OrderedGems
 
 group :doc do
   gem 'sdoc', require: false
@@ -72,24 +63,12 @@ group :test do
 end
 
 group :development do
-  gem 'htmlbeautifier'
+  gem 'rubocop', '~> 1.0', require: false
+  gem 'rubocop-rails', '~> 2.0', require: false
   gem 'ruby-lsp'
   gem 'solargraph'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  # Devtools panel for Rails development - loading from the GitHub repo
-  # (https://github.com/dejan/rails_panel/issues/209#issuecomment-2621877079_)
-  gem 'meta_request', github: 'dejan/rails_panel', ref: 'meta_request-v0.8.5'
-
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console'
-  # TODO: While running the rails app locally for testing you can set gems to your local path
-  # ! These 'local' paths do not work with a docker image - use the repo instead
-  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
-  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
 end
 
-# TODO: In production you want to set this to the gem from the epimorphics group package repository
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/dejan/rails_panel.git
-  revision: fed66f8a4ac2d11aa05ebf7d50e1d4d1e745423f
-  ref: meta_request-v0.8.5
-  specs:
-    meta_request (0.8.5)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,9 +75,9 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.10)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    ansi (1.5.0)
+    ansi (1.6.0)
     ast (2.4.3)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
@@ -94,7 +85,6 @@ GEM
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
-    bindex (0.8.1)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
@@ -122,7 +112,7 @@ GEM
       tilt
     date (3.5.1)
     diff-lcs (1.6.2)
-    dotenv (3.1.8)
+    dotenv (3.2.0)
     drb (2.2.3)
     erb (5.1.3)
     erubi (1.13.1)
@@ -133,11 +123,11 @@ GEM
       logger
     faraday-encoding (0.0.6)
       faraday
-    faraday-follow_redirects (0.3.0)
+    faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -156,27 +146,27 @@ GEM
       ffi (~> 1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    google-protobuf (4.33.6)
+    google-protobuf (4.34.1)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-aarch64-linux-gnu)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-aarch64-linux-musl)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-arm64-darwin)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-x86_64-darwin)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-x86_64-linux-gnu)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.33.6-x86_64-linux-musl)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
       bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
     govuk_elements_rails (3.0.2)
       govuk_frontend_toolkit (>= 5.2.0)
       rails (>= 4.1.0)
@@ -185,7 +175,7 @@ GEM
       railties (>= 3.1.0)
     govuk_template (0.26.0)
       rails (>= 3.1)
-    haml (7.0.2)
+    haml (7.2.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -195,16 +185,16 @@ GEM
       haml (>= 4.0.6)
       railties (>= 5.1)
     hashdiff (1.2.1)
-    htmlbeautifier (1.4.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.15.3)
+    irb (1.18.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.6.1)
-    jbuilder (2.14.1)
+    jaro_winkler (1.7.0)
+    jbuilder (2.15.0)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jquery-rails (4.6.1)
@@ -216,7 +206,7 @@ GEM
     js-routes (2.3.7)
       railties (>= 5)
       sorbet-runtime
-    json (2.15.2.1)
+    json (2.19.5)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -225,12 +215,6 @@ GEM
     leaflet-rails (1.9.5)
       actionpack (>= 4.2.0)
       railties (>= 4.2.0)
-    libv8-node (24.1.0.0)
-    libv8-node (24.1.0.0-aarch64-linux)
-    libv8-node (24.1.0.0-arm64-darwin)
-    libv8-node (24.1.0.0-x86_64-darwin)
-    libv8-node (24.1.0.0-x86_64-linux)
-    libv8-node (24.1.0.0-x86_64-linux-musl)
     lint_roller (1.1.0)
     lodash-rails (4.17.21)
       railties (>= 3.1)
@@ -240,7 +224,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.24.1)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -252,26 +236,26 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (5.26.2)
+    minitest (5.27.0)
     minitest-rails (8.1.0)
       minitest (~> 5.20)
       railties (>= 8.1.0, < 8.2.0)
-    minitest-reporters (1.7.1)
+    minitest-reporters (1.8.0)
       ansi
       builder
-      minitest (>= 5.0)
+      minitest (>= 5.0, < 7)
       ruby-progressbar
     minitest-spec-rails (7.4.1)
       minitest (>= 5.0)
       railties (>= 4.1)
-    mocha (2.7.1)
+    mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
     modernizr-rails (2.7.1)
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
-    net-http (0.7.0)
-      uri
-    net-imap (0.5.14)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -281,26 +265,26 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.18.10-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     open3 (0.2.1)
     ostruct (0.6.3)
-    parallel (1.27.0)
+    parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -308,28 +292,26 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
+    prism (1.9.0)
     prometheus-client (4.2.5)
       base64
-    psych (5.2.6)
+    psych (5.3.1)
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.1.0)
+    puma (7.2.0)
       nio4r (~> 2.0)
-    puma-metrics (1.4.2)
+    puma-metrics (1.5.0)
       prometheus-client (>= 0.10)
-      puma (>= 6, != 7.0.0)
+      puma (>= 6.6.0, != 7.0.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-contrib (2.5.0)
-      rack (< 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (8.1.3)
       actioncable (= 8.1.3)
@@ -349,8 +331,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -362,43 +344,43 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rbs (3.10.4)
       logger
       tsort
-    rdoc (6.15.1)
+    rdoc (6.17.0)
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
-    responders (3.1.1)
-      actionpack (>= 5.2)
-      railties (>= 5.2)
+    responders (3.2.0)
+      actionpack (>= 7.0)
+      railties (>= 7.0)
     reverse_markdown (3.0.2)
       nokogiri
     rexml (3.4.4)
-    rubocop (1.80.2)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.46.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.46.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-rails (2.33.4)
+      prism (~> 1.7)
+    rubocop-rails (2.35.1)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -410,24 +392,24 @@ GEM
       rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.2.2)
+    rubyzip (3.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
-    sass-embedded (1.97.3-aarch64-linux-gnu)
+    sass-embedded (1.99.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-aarch64-linux-musl)
+    sass-embedded (1.99.0-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-arm-linux-gnueabihf)
+    sass-embedded (1.99.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-arm-linux-musleabihf)
+    sass-embedded (1.99.0-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-arm64-darwin)
+    sass-embedded (1.99.0-arm64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-x86_64-darwin)
+    sass-embedded (1.99.0-x86_64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-x86_64-linux-gnu)
+    sass-embedded (1.99.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.97.3-x86_64-linux-musl)
+    sass-embedded (1.99.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -437,18 +419,19 @@ GEM
     sdoc (2.6.5)
       rdoc (>= 5.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.39.0)
+    selenium-webdriver (4.44.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (5.26.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.26.0)
-    sentry-ruby (5.26.0)
+    sentry-rails (6.5.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.5.0)
+    sentry-ruby (6.5.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     solargraph (0.59.1)
       ast (~> 2.4.3)
       backport (~> 1.2)
@@ -472,8 +455,7 @@ GEM
       yard (~> 0.9, >= 0.9.24)
       yard-activesupport-concern (~> 0.0)
       yard-solargraph (~> 0.1)
-    sorbet-runtime (0.5.12443)
-    spring (4.4.2)
+    sorbet-runtime (0.6.13224)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -483,27 +465,21 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stackprof (0.2.28)
-    stringio (3.1.9)
+    stringio (3.2.0)
     temple (0.10.4)
-    thor (1.4.0)
-    tilt (2.6.1)
-    timeout (0.4.4)
+    thor (1.5.0)
+    tilt (2.7.0)
+    timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (3.1.5)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    vcr (6.3.1)
-      base64
-    web-console (4.2.1)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
-    webmock (3.25.2)
+    vcr (6.4.0)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -520,15 +496,15 @@ GEM
       yard (>= 0.8)
     yard-solargraph (0.1.0)
       yard (~> 0.9)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.0)
 
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    json_rails_logger (2.2.0)
-      json
-      lograge
-      railties
+    json_rails_logger (2.3.0)
+      json (>= 1.8, < 5.0)
+      lograge (>= 0.10, < 2.0)
+      railties (>= 6.0, < 9.0)
     lr_common_styles (3.0.1)
       bootstrap (~> 5.3.2)
       font-awesome-rails (~> 4.7.0)
@@ -560,7 +536,6 @@ DEPENDENCIES
   capybara
   dartsass-sprockets (~> 3.2)
   dotenv
-  execjs
   faraday (~> 2.13, >= 2.13.0)
   faraday-encoding (~> 0.0, >= 0.0.6)
   faraday-follow_redirects (~> 0.3, >= 0.3.0)
@@ -569,37 +544,32 @@ DEPENDENCIES
   foreman
   get_process_mem
   haml-rails
-  htmlbeautifier
   jbuilder
   jquery-rails
   jquery-ui-rails
   js-routes
   json_rails_logger!
   leaflet-rails
-  libv8-node
   lr_common_styles!
-  meta_request!
   minitest-rails
   minitest-reporters
   minitest-spec-rails
   mocha
   ostruct
   prometheus-client
-  puma
+  puma (~> 7.0)
   puma-metrics
-  rails
+  rails (~> 8.1)
   responders
-  rubocop
-  rubocop-rails
+  rubocop (~> 1.0)
+  rubocop-rails (~> 2.0)
   ruby-lsp
   sdoc
   selenium-webdriver
-  sentry-rails
+  sentry-rails (~> 6.0)
   solargraph
-  spring
   stackprof
   vcr
-  web-console
   webmock
   yajl-ruby
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
 
   def read_data_file(filename)
     File.foreach(filename).with_object([]) do |line, result|
-      result << line.split.map(&:to_s).join(' ').upcase.strip unless line.strip.empty?
+      result << line.split.join(' ').upcase.strip unless line.strip.empty?
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,8 @@ end
 # Monkey-patch the bit of Rails that emits the start-up log message, so
 # that it is written out in JSON format that our combined logging
 # service can handle
-module Rails
+# TODO: remove when this app uses `epilog_rails`
+module Rails # rubocop:disable Style/OneClassPerFile
   # :nodoc:
   module Command
     # :nodoc:


### PR DESCRIPTION
Pins explicit version constraints on core gems to prevent unintended major version upgrades, removes unused development dependencies, and moves linting tools to the `development` group only.

### Changes

#### Version pins added
- `rails '~> 8.1'`
- `puma '~> 7.0'`
- `sentry-rails '~> 6.0'` (upgraded from v5)
- `rubocop '~> 1.0'`, `rubocop-rails '~> 2.0'`

#### Dependencies removed
- `execjs`, `libv8-node` — JS runtime no longer needed
- `spring` — development server pre-loader, unused
- `web-console` — in-browser IRB console, unused
- `meta_request` — RailsPanel devtools, unused
- `htmlbeautifier` — HTML formatting tool, unused
- `rack-contrib` — was only pulled in by `meta_request`

#### Structural changes
- Moved `rubocop` and `rubocop-rails` from the global gem group into `group :development` so they are not loaded in production

#### Dependency updates (via lock file)
Notable bumps pulled in by the above: `nokogiri` 1.18 → 1.19, `sentry-ruby` 5.26 → 6.5, `rubocop` 1.80 → 1.86, `prism` 1.4 → 1.9, `selenium-webdriver` 4.39 → 4.44, `google-protobuf` 4.33 → 4.34, `haml` 7.0 → 7.2.

### Test plan
- [x] `bundle install` completes without errors
- [x] Application boots in development
- [x] Test suite passes
- [x] No rubocop errors introduced
