### PR TITLE
Reapply "fix: resolve accessibility issues with ARIA attributes, fiel…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed invalid `aria-labelled-by` attributes on the report type selection page, corrected to `aria-labelledby` [#207](https://github.com/epimorphics/standard-reports-ui/issues/207).
+- Added missing `<legend>` elements to fieldsets across the report design workflow for screen reader accessibility.
+- Shortened overly long image alt text on the report type selection page.
+
 ## [2.3.3] - 2026-07-14
 
 ## Added

--- a/app/helpers/report_design_helper.rb
+++ b/app/helpers/report_design_helper.rb
@@ -2,12 +2,13 @@
 
 # :nodoc:
 module ReportDesignHelper # rubocop:disable Metrics/ModuleLength
-  def workflow_step_form(workflow)
+  def workflow_step_form(workflow, legend)
     step = workflow.current_step
 
     form_tag(workflow.form_action, method: 'get') do
       content_tag(:div, class: 'row') do
         concat(content_tag(:fieldset, class: 'col-sm-12 col-md-6') do
+          concat content_tag(:legend, legend, class: 'visually-hidden')
           concat layout_existing_values(workflow)
           concat layout_flash(step)
           concat layout_workflow_form(workflow, step)

--- a/app/views/report_design/select_aggregation_type.html.haml
+++ b/app/views/report_design/select_aggregation_type.html.haml
@@ -13,4 +13,4 @@
     or grouped by smaller areas. For example, the data for one county could
     be grouped by the administrative districts within that county.
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "How do you want to group the data within '#{selected_area_summary( @workflow )}'?" )

--- a/app/views/report_design/select_area_type.html.haml
+++ b/app/views/report_design/select_area_type.html.haml
@@ -14,4 +14,4 @@
     Please select the type of geographical area you want the report
     to cover:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Which sort of geographical area do you want to cover?" )

--- a/app/views/report_design/select_country.html.haml
+++ b/app/views/report_design/select_country.html.haml
@@ -11,4 +11,4 @@
   %p
     Choose which country the report should cover:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a country" )

--- a/app/views/report_design/select_county.html.haml
+++ b/app/views/report_design/select_county.html.haml
@@ -11,7 +11,7 @@
   %p
     Enter the name of the county you wish the report to cover:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a county" )
 
   :javascript
     $( function() {

--- a/app/views/report_design/select_dates.html.haml
+++ b/app/views/report_design/select_dates.html.haml
@@ -19,6 +19,7 @@
 
   = form_tag( @workflow.form_action, method: "get" ) do
     %fieldset
+      %legend.visually-hidden Which time period should the report cover?
       = layout_existing_values( @workflow )
 
       %h2.heading-small Latest available

--- a/app/views/report_design/select_district.html.haml
+++ b/app/views/report_design/select_district.html.haml
@@ -11,7 +11,7 @@
   %p
     Enter the name of the district (i.e. local authority) you wish the report to cover:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a district" )
 
   :javascript
     $( function() {

--- a/app/views/report_design/select_options.html.haml
+++ b/app/views/report_design/select_options.html.haml
@@ -11,4 +11,4 @@
   %p
     You can restrict the report to only show properties that have just been built, or not:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Additional options" )

--- a/app/views/report_design/select_pc_area.html.haml
+++ b/app/views/report_design/select_pc_area.html.haml
@@ -13,4 +13,4 @@
     the first one or two letters of a UK postcode, for example &quot;B&quot;
     or &quot;TA&quot;
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a postcode area" )

--- a/app/views/report_design/select_pc_district.html.haml
+++ b/app/views/report_design/select_pc_district.html.haml
@@ -13,4 +13,4 @@
     the first part of a UK postcode, up to the space. For example &quot;B17&quot;
     or &quot;TA9&quot;
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a postcode district" )

--- a/app/views/report_design/select_pc_sector.html.haml
+++ b/app/views/report_design/select_pc_sector.html.haml
@@ -13,4 +13,4 @@
     the first part of a UK postcode, up to and including the first digit after the space.
     For example &quot;B17 0&quot; or &quot;TA9 3&quot;
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a postcode sector" )

--- a/app/views/report_design/select_region.html.haml
+++ b/app/views/report_design/select_region.html.haml
@@ -11,7 +11,7 @@
   %p
     Choose which region of the country the report should cover:
 
-  = workflow_step_form( @workflow )
+  = workflow_step_form( @workflow, "Select a region" )
 
   :javascript
     $( function() {

--- a/app/views/report_design/select_report.html.haml
+++ b/app/views/report_design/select_report.html.haml
@@ -17,8 +17,9 @@
   = form_tag( @workflow.form_action, method: "get" ) do
     .row
       %fieldset.col-sm-12
+        %legend.visually-hidden Select a report type
         %ul.list-unstyled
-          %li{"aria-labelled-by": "average-prices-report"}
+          %li{"aria-labelledby": "average-prices-report"}
             .o-form-control
               %label.o-form-control--label
                 = radio_button_tag( step.form_param, step_values[0].value, step_values[0].active?, class: "o-form-control--input", required: true )
@@ -30,8 +31,8 @@
                   %div.panel
                     %picture
                       %source{ srcset: image_path( "average-prices-report-screenshot.png" ), media: "(min-width: 768px)" }
-                      %img{ src: image_path( "average-prices-report-screenshot.png" ), alt: "Screenshot of example average prices report. Excel table showing 2015 house prices and sales volumes for East Anglia counties including Cambridgeshire and Norfolk." }
-          %li{"aria-labelled-by": "banded-prices-report"}
+                      %img{ src: image_path( "average-prices-report-screenshot.png" ), alt: "Example average prices report showing house prices and sales volumes by county." }
+          %li{"aria-labelledby": "banded-prices-report"}
             .o-form-control
               %label.o-form-control--label
                 = radio_button_tag( step.form_param, step_values[1].value, step_values[1].active?, class: "o-form-control--input", required: true )
@@ -43,7 +44,7 @@
                   %div.panel
                     %picture
                       %source{ srcset: image_path( "banded-prices-report-screenshot.png" ), media: "(min-width: 768px)" }
-                      %img{ src: image_path( "banded-prices-report-screenshot.png" ), alt: "Screenshot of example banded prices report. Excel table showing 2015 sales volumes by price band for different property types across East Anglia counties, including Cambridgeshire and Norfolk." }
+                      %img{ src: image_path( "banded-prices-report-screenshot.png" ), alt: "Example banded prices report showing sales volumes by price band and property type, by county." }
 
       = layout_existing_values( @workflow )
       = layout_submit_button( @workflow )


### PR DESCRIPTION
- Fixed invalid aria-labelled-by attributes on the report type selection page, corrected to aria-labelledby

The following two issues are just alerts but are included in this PR 
- Added missing <legend> elements to fieldsets across the report design workflow
- Shortened overly long image alt text on the report type selection page

Relates to this ticket https://github.com/epimorphics/standard-reports-ui/issues/207